### PR TITLE
Fixed connect call for VisibleTodoList

### DIFF
--- a/22-Generating_Containers_with_connect()_from_React_Redux_(VisibleTodoList).md
+++ b/22-Generating_Containers_with_connect()_from_React_Redux_(VisibleTodoList).md
@@ -59,7 +59,7 @@ const { connect } = ReactRedux;
 const VisibleTodoList = connect(
   mapStateToProps,
   mapDispatchToProps
-)(TodoApp)
+)(TodoList)
 
 ```
 


### PR DESCRIPTION
Check out 3:39 in https://egghead.io/lessons/javascript-redux-generating-containers-with-connect-from-react-redux-visibletodolist

VisibleTodoList should be connected to TodoList, not TodoApp.
