### PR TITLE
Clarity of what is being invoked to cause push

### DIFF
--- a/03-Implementing_Store_from_Scratch.md
+++ b/03-Implementing_Store_from_Scratch.md
@@ -6,7 +6,7 @@ We just used the `createStore()` function, but in order to understand it better,
 
 We know that we need to pass in the `reducer` function, and that `getState()` will return the current value of `state`. We also know that we need to be able to dispatch actions, and subscribe.
 
-Because the `subscribe()` function can be called many times, we need to keep track of all the change listeners, so we create an array (listeners) that, when called, will push in the new listener to the array.
+Because the `subscribe()` function can be called many times, we need to keep track of all the change listeners, so we create an array of listeners; everytime subscribe() is invoked we will push in the new listener to the array.
 
 Dispatching an action is the only way to change the internal state, so we calculate the new state as the result of calling `reducer()` with the current `state` and the `action` being dispatched. After the `state` is updated, we notify every change listener by calling them.
 


### PR DESCRIPTION
The original text lacked clarity of what exactly was being invoked that will cause a new push to the array of listeners. It made it seem as if the array was being called, not the subscribe() method.